### PR TITLE
Fix tag search from selecting tags

### DIFF
--- a/lib/screens/filtered_bookmarks/provider/filtered_bookmarks.provider.dart
+++ b/lib/screens/filtered_bookmarks/provider/filtered_bookmarks.provider.dart
@@ -30,7 +30,7 @@ FutureOr<void> tagBookmarksRequest(TagBookmarksRequestRef ref, Tag? tag, String?
   }
 
   final bookmarksResult = await ref.read(apiClientProvider)!.fetchBookmarks(
-        q: tag != null ? tag.name : tagResult!.content!.name,
+        q: tag != null ? "#${tag.name}" : tagResult!.content!.name,
         limit: limit,
         offset: 0,
       );


### PR DESCRIPTION
Hi, firstly thank you for developing this app. Finally there's a LinkThing (iOS) similar app for Android. 👍🏻

I noticed a bug while using the app. When selecting tags in Tag Screen, the query uses the default keyword without the hashtag, which causes the resultant data to be wrong.

This pull request should fix it.