### PR TITLE
Don't capitalize tags

### DIFF
--- a/lib/screens/bookmarks/ui/bookmark_form_modal.dart
+++ b/lib/screens/bookmarks/ui/bookmark_form_modal.dart
@@ -312,6 +312,7 @@ class _ModalContent extends ConsumerWidget {
                           controller: provider.tagsController,
                           onChanged: ref.read(bookmarkFormProvider.notifier).validateTagInput,
                           suggestions: tags.value?.content?.results?.map((t) => t.name!).toList() ?? [],
+                          textCapitalization: TextCapitalization.none,
                           decoration: InputDecoration(
                             border: const OutlineInputBorder(
                               borderRadius: BorderRadius.all(


### PR DESCRIPTION
I'd assume most users are using tags in lower case, so let's disable automatic capitalization when adding tags to a new bookmark.