### PR TITLE
Always use the default browser's custom tab

### DIFF
--- a/lib/utils/open_url.dart
+++ b/lib/utils/open_url.dart
@@ -13,6 +13,7 @@ void openUrlCustomTab(String url) async {
           shareState: flutter_custom_tabs.CustomTabsShareState.browserDefault,
           urlBarHidingEnabled: true,
           showTitle: true,
+          browser: flutter_custom_tabs.CustomTabsBrowserConfiguration(prefersDefaultBrowser: true),
         ),
         safariVCOptions: const flutter_custom_tabs.SafariViewControllerOptions(
           barCollapsingEnabled: true,


### PR DESCRIPTION
Fixes #32.

In the current behaviour Chrome is always used, with the fixed behaviour, my default browser (Firefox) is now used. You can observe the three-dot menus are now different.

### Current behaviour
[current-behaviour.webm](https://github.com/user-attachments/assets/2a68201b-cea7-4352-8d63-dae35d60d47c)


### Expected behaviour
[expected-behaviour.webm](https://github.com/user-attachments/assets/4c99a933-86dc-4c76-8f62-235d1f73e018)
